### PR TITLE
Use of new offline software library

### DIFF
--- a/CODAChainDev/gridrun.sh
+++ b/CODAChainDev/gridrun.sh
@@ -36,11 +36,11 @@ ls -lh | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 # setup enviroment
 #is_grid=1
 if [ $is_grid == 1 ]; then
-  echo "source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh"
-  source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh
+  echo "source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh"
+  source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh
 else
-  echo "source /e906/app/software/osg/users/yuhw/e1039/setup.sh"
-  source /e906/app/software/osg/users/yuhw/e1039/setup.sh
+  echo "source /e906/app/software/osg/software/e1039/this-e1039.sh"
+  source /e906/app/software/osg/software/e1039/this-e1039.sh
 fi
 
 # test enviroment

--- a/E1039Shielding/gridrun.sh
+++ b/E1039Shielding/gridrun.sh
@@ -28,11 +28,11 @@ pwd | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 tar -xzvf $CONDOR_DIR_INPUT/input.tar.gz
 ls -lh | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 
-source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh
+source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh
 echo `which root`
 
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libktracker.so
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libg4detectors.so
+ldd $E1039_CORE/lib/libktracker.so
+ldd $E1039_CORE/lib/libg4detectors.so
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 
 time root -b -q Fun4E1039Shielding.C\($nevents,$gap,$shield,$target_pos\)

--- a/HodoAccGap/gridrun.sh
+++ b/HodoAccGap/gridrun.sh
@@ -27,11 +27,11 @@ pwd | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 tar -xzvf $CONDOR_DIR_INPUT/input.tar.gz
 ls -lh | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 
-source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh
+source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh
 echo `which root`
 
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libktracker.so
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libg4detectors.so
+ldd $E1039_CORE/lib/libktracker.so
+ldd $E1039_CORE/lib/libg4detectors.so
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 
 time root -b -q Fun4HodoAccGap.C\($nevents,$gap,$target_pos\)

--- a/SimChainDev/gridrun.sh
+++ b/SimChainDev/gridrun.sh
@@ -21,6 +21,7 @@ if [ -z ${CONDOR_DIR_OUTPUT+x} ];
 fi
 
 echo "hello, grid." | tee out.txt $CONDOR_DIR_OUTPUT/out.txt
+echo "HOST = $HOSTNAME" | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 pwd | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 
 tar -xzvf $CONDOR_DIR_INPUT/input.tar.gz

--- a/SimChainDev/gridrun.sh
+++ b/SimChainDev/gridrun.sh
@@ -26,13 +26,13 @@ pwd | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 tar -xzvf $CONDOR_DIR_INPUT/input.tar.gz
 ls -lh | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 
-source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh
+source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh
 #source /e906/app/software/osg/users/yuhw/e1039/setup.sh
 #export LD_LIBRARY_PATH=/cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/install/lib:$LD_LIBRARY_PATH
 echo `which root`
 
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libktracker.so
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libg4detectors.so
+ldd $E1039_CORE/lib/libktracker.so
+ldd $E1039_CORE/lib/libg4detectors.so
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 
 time root -b -q Fun4Sim.C\($nevents\)

--- a/SimChainDev/gridsub.sh
+++ b/SimChainDev/gridsub.sh
@@ -50,6 +50,7 @@ do
   cmd="$cmd -L $work/$id/log/log.txt"
   cmd="$cmd -f $work/input.tar.gz"
   cmd="$cmd -d OUTPUT $work/$id/out"
+  cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
   cmd="$cmd file://`which $work/$id/gridrun_new.sh`"
 
   if [ $do_sub == 1 ]; then

--- a/SimChainDev/gridsub.sh
+++ b/SimChainDev/gridsub.sh
@@ -17,7 +17,7 @@ fi
 echo "njobs=$njobs"
 echo "nevents=$nevents"
 
-macros=/e906/app/users/$USER/e1039-analysis/SimChainDev
+macros=$(dirname $(readlink -f $BASH_SOURCE))
 
 sed "s/nevents=NAN/nevents=$nevents/"             $macros/gridrun.sh > $macros/gridrun_new.sh 
 sed -i "s/nmu=NAN/nmu=$nmu/"                      $macros/gridrun_new.sh
@@ -33,7 +33,7 @@ mkdir -p $work
 chmod -R 01755 $work
 
 cd $macros
-tar -czvf $work/input.tar.gz *.C *.cfg *.opts trigger_*.txt
+tar -czvf $work/input.tar.gz *.C *.cfg *.opts
 cd -
 
 for (( id=1; id<=$njobs; id++ ))
@@ -63,3 +63,10 @@ do
     cd -
   fi
 done
+
+## When your job fails due to bad grid nodes,
+## you can use the following option to exclude those nodes;
+##   cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
+## Valid site names are listed here;
+## https://cdcvs.fnal.gov/redmine/projects/fife/wiki/Information_about_job_submission_to_OSG_sites
+## According to the Fermilab Service Desk, the "--blacklist" option has a known defect.

--- a/TargetSim/gridrun.sh
+++ b/TargetSim/gridrun.sh
@@ -25,11 +25,11 @@ pwd | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 tar -xzvf $CONDOR_DIR_INPUT/input.tar.gz
 ls -lh | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 
-source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh
+source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh
 echo `which root`
 
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libktracker.so
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libg4detectors.so
+ldd $E1039_CORE/lib/libktracker.so
+ldd $E1039_CORE/lib/libg4detectors.so
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 
 time root -b -q Fun4All_G4_E1039_R2_V2.C\($nevents\)

--- a/TrkDev/gridrun.sh
+++ b/TrkDev/gridrun.sh
@@ -26,14 +26,11 @@ pwd | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 tar -xzvf $CONDOR_DIR_INPUT/input.tar.gz
 ls -lh | tee -a out.txt $CONDOR_DIR_OUTPUT/out.txt
 
-source /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/setup.sh
-export LD_LIBRARY_PATH=/cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/externals/lib:$LD_LIBRARY_PATH
-export LD_LIBRARY_PATH=/cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/install/lib:$LD_LIBRARY_PATH
-#export LD_LIBRARY_PATH=/e906/app/software/osg/users/yuhw/install/lib:$LD_LIBRARY_PATH
+source /cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039/this-e1039.sh
 echo `which root`
 
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libktracker.so
-ldd /cvmfs/seaquest.opensciencegrid.org/seaquest/users/yuhw/e1039/offline_main/lib/libg4detectors.so
+ldd $E1039_CORE/lib/libktracker.so
+ldd $E1039_CORE/lib/libg4detectors.so
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 
 time root -b -q Fun4PatternDB.C\($nevents,$nmu\)


### PR DESCRIPTION
A new offline software library has been set up under "/cvmfs/seaquest.opensciencegrid.org/seaquest/software/e1039".  This update is to adopt the new library.

In "SimChainDev/gridsub.sh", the "--append_condor_requirements" option of "jobsub_submit" was added in order to exclude the bad grid nodes (UCSD) on which the job always fails.