### PR TITLE
Use of E1039 Singularity image in jobsub_submit

### DIFF
--- a/CODAChainDev/gridsub.sh
+++ b/CODAChainDev/gridsub.sh
@@ -58,8 +58,10 @@ do
   rsync -a $macros/gridrun.sh $local_work_dir/gridrun.sh
 
   if [ $do_sub == 1 ]; then
-    cmd="jobsub_submit"
-    cmd="$cmd -g --OS=SL7 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
+    cmd="jobsub_submit --grid"
+    cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+    cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+    cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
     cmd="$cmd --mail_never"
     cmd="$cmd -L $local_work_dir/log/log.txt"
     cmd="$cmd -f $local_work_dir/input.tar.gz"

--- a/E1039Shielding/gridsub.sh
+++ b/E1039Shielding/gridsub.sh
@@ -46,8 +46,10 @@ do
 
   rsync -av $macros/gridrun_new.sh $work/$id/gridrun_new.sh
 
-  cmd="jobsub_submit"
-  cmd="$cmd -g --OS=SL6 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC -e IFDHC_VERSION --expected-lifetime='short'"
+  cmd="jobsub_submit --grid"
+  cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+  cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+  cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
   cmd="$cmd --mail_never"
   cmd="$cmd -L $work/$id/log/log.txt"
   cmd="$cmd -f $work/input.tar.gz"

--- a/HodoAccGap/gridsub.sh
+++ b/HodoAccGap/gridsub.sh
@@ -46,8 +46,10 @@ do
 
   rsync -av $macros/gridrun_new.sh $work/$id/gridrun_new.sh
 
-  cmd="jobsub_submit"
-  cmd="$cmd -g --OS=SL6 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC -e IFDHC_VERSION --expected-lifetime='short'"
+  cmd="jobsub_submit --grid"
+  cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+  cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+  cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
   cmd="$cmd --mail_never"
   cmd="$cmd -L $work/$id/log/log.txt"
   cmd="$cmd -f $work/input.tar.gz"

--- a/RecoDev/grid_script/gridsub_data.sh
+++ b/RecoDev/grid_script/gridsub_data.sh
@@ -54,15 +54,14 @@ for run_num in $(cat $run_list) ; do
     rsync -av $dir_macros/gridrun_data.sh $work/$job_name/gridrun_data.sh
 
     if [ $do_sub == 1 ]; then
-      cmd="jobsub_submit"
-      cmd="$cmd -g --OS=SL7 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
-      #cmd="$cmd -g --OS=SL7 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
+      cmd="jobsub_submit --grid"
+      cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+      cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+      cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
       cmd="$cmd --mail_never"
       cmd="$cmd -L $work/$job_name/log/log.txt"
       cmd="$cmd -f $work/input.tar.gz"
       cmd="$cmd -d OUTPUT $work/$job_name/out"
-      cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
-      cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"SU-ITS\")'"
       cmd="$cmd -f $data_path"
       cmd="$cmd file://`which $work/$job_name/gridrun_data.sh` $nevents $run_num $data_file"
       echo "$cmd"

--- a/SimChainDev/gridsub.sh
+++ b/SimChainDev/gridsub.sh
@@ -40,13 +40,14 @@ do
   rsync -av $dir_macros/gridrun.sh $work/$id/gridrun.sh
 
   if [ $do_sub == 1 ]; then
-    cmd="jobsub_submit"
-    cmd="$cmd -g --OS=SL7 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
+    cmd="jobsub_submit --grid"
+    cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+    cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+    cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
     cmd="$cmd --mail_never"
     cmd="$cmd -L $work/$id/log/log.txt"
     cmd="$cmd -f $work/input.tar.gz"
     cmd="$cmd -d OUTPUT $work/$id/out"
-    cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
     cmd="$cmd file://`which $work/$id/gridrun.sh` $nevents $id"
     echo "$cmd"
     $cmd
@@ -58,10 +59,3 @@ do
     cd -
   fi
 done 2>&1 | tee log_gridsub.txt
-
-## When your job fails due to bad grid nodes,
-## you can use the following option to exclude those nodes;
-##   cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
-## Valid site names are listed here;
-## https://cdcvs.fnal.gov/redmine/projects/fife/wiki/Information_about_job_submission_to_OSG_sites
-## According to the Fermilab Service Desk, the "--blacklist" option has a known defect.

--- a/TargetSim/gridsub.sh
+++ b/TargetSim/gridsub.sh
@@ -42,8 +42,10 @@ do
 
   rsync -av $macros/gridrun_new.sh $work/$id/gridrun_new.sh
 
-  cmd="jobsub_submit"
-  cmd="$cmd -g --OS=SL6 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
+  cmd="jobsub_submit --grid"
+  cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+  cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+  cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
   cmd="$cmd --mail_never"
   cmd="$cmd -L $work/$id/log/log.txt"
   cmd="$cmd -f $work/input.tar.gz"

--- a/TriggerAna/setup.sh
+++ b/TriggerAna/setup.sh
@@ -1,6 +1,6 @@
 DIR_TOP=$(dirname $(readlink -f $BASH_SOURCE))
 
-#source /e906/app/software/osg/software/e1039/this-e1039.sh
+source /e906/app/software/osg/software/e1039/this-e1039.sh
 #source /e906/app/software/osg/users/$USER/e1039/core/this-e1039.sh
 export LD_LIBRARY_PATH=$DIR_TOP/inst/lib:$LD_LIBRARY_PATH
 

--- a/TriggerAna/work/gridsub.sh
+++ b/TriggerAna/work/gridsub.sh
@@ -44,13 +44,14 @@ do
   rsync -av $dir_macros/gridrun.sh $work/$id/gridrun.sh
 
   if [ $do_sub == 1 ]; then
-    cmd="jobsub_submit"
-    cmd="$cmd -g --OS=SL7 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
+    cmd="jobsub_submit --grid"
+    cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+    cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+    cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='$LIFE_TIME'"
     cmd="$cmd --mail_never"
     cmd="$cmd -L $work/$id/log/log.txt"
     cmd="$cmd -f $work/input.tar.gz"
     cmd="$cmd -d OUTPUT $work/$id/out"
-    cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
     cmd="$cmd file://`which $work/$id/gridrun.sh` $nfile $list $id"
     echo "$cmd"
     $cmd
@@ -62,10 +63,3 @@ do
     cd -
   fi
 done 2>&1 | tee log_gridsub.txt
-
-## When your job fails due to bad grid nodes,
-## you can use the following option to exclude those nodes;
-##   cmd="$cmd --append_condor_requirements='(TARGET.GLIDEIN_Site isnt \"UCSD\")'"
-## Valid site names are listed here;
-## https://cdcvs.fnal.gov/redmine/projects/fife/wiki/Information_about_job_submission_to_OSG_sites
-## According to the Fermilab Service Desk, the "--blacklist" option has a known defect.

--- a/TrkDev/gridsub.sh
+++ b/TrkDev/gridsub.sh
@@ -44,8 +44,10 @@ do
 
   rsync -av $macros/gridrun_new.sh $work/$id/gridrun_new.sh
 
-  cmd="jobsub_submit"
-  cmd="$cmd -g --OS=SL6 --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
+  cmd="jobsub_submit --grid"
+  cmd="$cmd -l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"'"
+  cmd="$cmd --append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)'"
+  cmd="$cmd --use_gftp --resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE -e IFDHC_VERSION --expected-lifetime='short'"
   cmd="$cmd --mail_never"
   cmd="$cmd -L $work/$id/log/log.txt"
   cmd="$cmd -f $work/input.tar.gz"


### PR DESCRIPTION
I have modified all `gridsub.sh`-type scripts so as to use the `e1039-sl7` Singularity image on CVMFS.  I have together removed the jobsub_submit option that excludes the bad nodes via `TARGET.GLIDEIN_Site`.