### PR TITLE
New PYTHIA8 config files for J/psi, direct J/psi and psi'.

### DIFF
--- a/SimChainDev/Fun4Sim.C
+++ b/SimChainDev/Fun4Sim.C
@@ -84,8 +84,8 @@ int Fun4Sim(const int nevent = 10)
   if(gen_pythia8) {    
     PHPythia8 *pythia8 = new PHPythia8();
     //pythia8->Verbosity(99);
-//    pythia8->set_config_file("phpythia8_DY.cfg");
-    pythia8->set_config_file("phpythia8_Jpsi.cfg");
+    //pythia8->set_config_file("phpythia8_DY.cfg");
+    pythia8->set_config_file("phpythia8_Jpsi.cfg"); // Jpsi, Jpsi_direct, psip
     if(legacyVtxGen) pythia8->enableLegacyVtxGen();
     else{
       pythia8->set_vertex_distribution_mean(0, 0, target_coil_pos_z, 0);
@@ -196,7 +196,6 @@ int Fun4Sim(const int nevent = 10)
       e906legacy->set_massRange(0.23, 10.0);// 0.22 and above     
       e906legacy->enableDrellYanGen();
     }
-   
    
     if(Psip_gen){ 
       e906legacy->set_xfRange(0.1, 0.5); //[-1.,1.]

--- a/SimChainDev/phpythia8_DY.cfg
+++ b/SimChainDev/phpythia8_DY.cfg
@@ -1,20 +1,27 @@
-! Pythia configuration file for Drell-Yan pp/pn collisions
+!! SpinQuest PYTHIA8 configuration for Drell-Yan in pp/pn.
+!!
+!! You should adjust mHatMin when interested in low-mass region.
 
-! PDF:pSet = 7                     ! CTEQ6L
-!ParticleDecays:limitTau = off     ! Only decays the unstable particles
-!ParticleDecays:limitTau0 = off    ! Only decays the unstable particles
-WeakSingleBoson:ffbar2ffbar(s:gm) = on     ! ffbar -> gamma* -> ffbar
-
+! Beam settings
 Beams:frameType = 2
 Beams:idA       = 2212
 Beams:eA        = 120.
 Beams:eB        = 0.
 Beams:allowVertexSpread = on
 
-PhaseSpace:mHatMin = 4 ! (default = 4.; minimum = 0.)
+! PDF etc.
+#PDF:pSet = 7                     ! CTEQ6L
+#ParticleDecays:limitTau = off    ! Only decays the unstable particles
+#ParticleDecays:limitTau0 = off   ! Only decays the unstable particles
 
-!! When you study low pT region such as low mass and |cos(theta)|~1,
-!! you better confirm the generated kinematics is not distorted,
-!! by varying these parameters;
-! PhaseSpace:pTHatMinDiverge = 0.5 ! (default = 1.0; minimum = 0.5)
-! BeamRemnants:primordialKT = no
+! Process selection
+WeakSingleBoson:ffbar2ffbar(s:gm) = on     ! ffbar -> gamma* -> ffbar
+
+! Cuts
+PhaseSpace:mHatMin = 4.0  ! default = 4.; minimum = 0.
+
+! When you study low pT region such as low mass and |cos(theta)|~1,
+! you better confirm the generated kinematics is not distorted,
+! by varying these parameters;
+#PhaseSpace:pTHatMinDiverge = 0.5 ! (default = 1.0; minimum = 0.5)
+#BeamRemnants:primordialKT = no

--- a/SimChainDev/phpythia8_Jpsi.cfg
+++ b/SimChainDev/phpythia8_Jpsi.cfg
@@ -27,10 +27,10 @@ Next:numberShowInfo = 0        ! print event information n times
 #PDF:pSet = 7 ! CTEQ6L
 
 ! Process selection
+! Comment out the last two lines when you study the _absolute_ J/psi yield.
 Charmonium:all = on
 443:onMode     = off    ! Prohibit all J/psi decay modes
 443:onIfAny    = 13 -13 ! Except mu+/mu-
-! Comment out the last two lines when you study the _absolute_ J/psi yield.
 
 ! Cuts
 PhaseSpace:mHatMin = 2.5

--- a/SimChainDev/phpythia8_Jpsi.cfg
+++ b/SimChainDev/phpythia8_Jpsi.cfg
@@ -26,8 +26,10 @@ Next:numberShowInfo = 0        ! print event information n times
 #PDF:LHAPDFset = NNPDF23_lo_as_0119_qed
 #PDF:pSet = 7 ! CTEQ6L
 
-! Process selection
-! Comment out the last two lines when you study the _absolute_ J/psi yield.
+! Process selection.
+! The last two lines set the BR of the dimuon decay mode to 100%. 
+! Thus you have to scale the resultant dimuon yield by the physical 
+! BR value (5.96%) when studying the absolute value of J/psi yield.
 Charmonium:all = on
 443:onMode     = off    ! Prohibit all J/psi decay modes
 443:onIfAny    = 13 -13 ! Except mu+/mu-

--- a/SimChainDev/phpythia8_Jpsi_direct.cfg
+++ b/SimChainDev/phpythia8_Jpsi_direct.cfg
@@ -1,0 +1,45 @@
+!! SpinQuest PYTHIA8 configuration for direct (i.e. non-feed-down) J/psi.
+!! 
+!! The feed-downs are disabled. Analyzer has to check the origin of each
+!! dimuon, as explained in "phpythia8_Jpsi.cfg".
+
+! Beam settings
+Beams:frameType = 2
+Beams:idA       = 2212
+Beams:eA        = 120.
+Beams:eB        = 0.
+Beams:allowVertexSpread = on
+
+! Settings related to output in init(), next() and stat()
+Init:showChangedSettings = on
+#Next:numberCount = 0          ! print message every n events
+Next:numberShowInfo = 0        ! print event information n times
+#Next:numberShowProcess = 1    ! print process record n times
+#Next:numberShowEvent = 1      ! print event record n times
+
+! PDF 
+#PDF:useLHAPDF = on
+#PDF:LHAPDFset = CT10.LHgrid
+#PDF:LHAPDFset = NNPDF23_lo_as_0119_qed
+#PDF:pSet = 7 ! CTEQ6L
+
+! Process selection
+Charmonium:all = on
+443:onMode     = off    ! J/psi
+443:onIfAny    = 13 -13 ! mu+/mu-
+100443:onMode  = off    ! psip
+9940103:onMode = off    ! psip[3S1(8)]
+9941103:onMode = off    ! psip[1S0(8)]
+9942103:onMode = off    ! psip[3PJ(8)]
+445:onMode     = off    ! chi_c2(1P)
+10441:onMode   = off    ! chi_c0(1P)
+20443:onMode   = off    ! chi_c0(1P)
+9940005:onMode = off    ! chi_c2(1P)[3S1(8)]
+9940011:onMode = off    ! chi_c0(1P)[3S1(8)]
+9940023:onMode = off    ! chi_c1(1P)[3S1(8)]
+30443:onMode   = off    ! psi(3770)
+9942033:onMode = off    ! psi(3770)[3PJ(8)]
+
+! Cuts
+PhaseSpace:mHatMin = 2.5
+#PhaseSpace:pTHatMin = 1.0

--- a/SimChainDev/phpythia8_psip.cfg
+++ b/SimChainDev/phpythia8_psip.cfg
@@ -1,10 +1,7 @@
-!! SpinQuest PYTHIA8 configuration for J/psi.
+!! SpinQuest PYTHIA8 configuration for psiprime.
 !! 
-!! Generated dimuon events are mostly J/psi but not limited to it because 
-!! PHPy8ParticleTrigger does not require mu+ and mu- to originate from single
-!! parent.  Also the feed-downs are included.  Thus analyzer has to check
-!! the origin of each dimuon, by looking at the truth mass of each dimuon or
-!! the subprocess ID of each event.
+!! Analyzer has to check the origin of each dimuon, 
+!! as explained in "phpythia8_Jpsi.cfg".
 
 ! Beam settings
 Beams:frameType = 2
@@ -28,9 +25,23 @@ Next:numberShowInfo = 0        ! print event information n times
 
 ! Process selection
 Charmonium:all = on
-443:onMode     = off    ! Prohibit all J/psi decay modes
-443:onIfAny    = 13 -13 ! Except mu+/mu-
+100443:onMode  = off     ! psip
+100443:onIfAny = 13 -13  ! psip -> mu+ mu-
 ! Comment out the last two lines when you study the _absolute_ J/psi yield.
+
+! Further process selection
+443:onMode     = off     ! J/psi
+9940003:onMode = off     ! J/psi[3S1(8)]
+9941003:onMode = off     ! J/psi[1S0(8)]
+9942003:onMode = off     ! J/psi[3PJ(8)]
+445:onMode     = off     ! chi_c2(1P)
+10441:onMode   = off     ! chi_c0(1P)
+20443:onMode   = off     ! chi_c1(1P)
+9940005:onMode = off     ! chi_c2(1P)[3S1(8)]
+9940011:onMode = off     ! chi_c0(1P)[3S1(8)]
+9940023:onMode = off     ! chi_c1(1P)[3S1(8)]
+30443:onMode   = off     ! psi(3770)
+9942033:onMode = off     ! psi(3770)[3PJ(8)]
 
 ! Cuts
 PhaseSpace:mHatMin = 2.5

--- a/SimChainDev/phpythia8_psip.cfg
+++ b/SimChainDev/phpythia8_psip.cfg
@@ -23,11 +23,13 @@ Next:numberShowInfo = 0        ! print event information n times
 #PDF:LHAPDFset = NNPDF23_lo_as_0119_qed
 #PDF:pSet = 7 ! CTEQ6L
 
-! Process selection
+! Process selection.
+! The last two lines set the BR of the dimuon decay mode to 100%. 
+! Thus you have to scale the resultant dimuon yield by the physical 
+! BR value (0.80%) when studying the absolute value of psip yield.
 Charmonium:all = on
 100443:onMode  = off     ! psip
 100443:onIfAny = 13 -13  ! psip -> mu+ mu-
-! Comment out the last two lines when you study the _absolute_ J/psi yield.
 
 ! Further process selection
 443:onMode     = off     ! J/psi


### PR DESCRIPTION
Here I make this PR for our record, because the default setting of the PYTHIA8 J/psi production (`phpythia8_Jpsi.cfg`) will change slightly.  

I removed the following lines from `phpythia8_Jpsi.cfg`, because they distort the amounts of feed-downs from psi' and chi_c to J/psi; 
```
100443:onMode = off
100443:onIfAny = 13 -13
```

psi' alone can be produced with the new config file, `phpythia8_psip.cfg`.  The direct (i.e. non-feed-down) component of J/psi can be produced with `phpythia8_Jpsi_direct.cfg`.