### PR TITLE
Modification of job-submission scripts for jobsub_lite.

### DIFF
--- a/CODAChainDev/gridsub.sh
+++ b/CODAChainDev/gridsub.sh
@@ -31,7 +31,7 @@ do
 
   # prepare $workdir
   if [ $do_sub == 1 ]; then
-  local_work_dir=/pnfs/e906/persistent/users/$USER/CODAChainDev/$jobname/$run_num/
+  local_work_dir=/pnfs/e1039/scratch/users/$USER/CODAChainDev/$jobname/$run_num/
   else
   local_work_dir=$macros/scratch/$jobname/$run_num/
   fi

--- a/CalibChamXT/work/check_job.sh
+++ b/CalibChamXT/work/check_job.sh
@@ -2,7 +2,7 @@
 ## A temporary script to check the status of jobs submitted.
 DIR_BASE=$(dirname $(readlink -f $BASH_SOURCE))
 
-DIR_DATA=/pnfs/e1039/scratch/$USER/CalibChamXT/main
+DIR_DATA=/pnfs/e1039/scratch/users/$USER/CalibChamXT/main
 DIR_TMP=scratch
 LOOP=no
 

--- a/CalibChamXT/work/copy_dst.sh
+++ b/CalibChamXT/work/copy_dst.sh
@@ -3,7 +3,7 @@
 
 LIST_RUN="list_run.txt"
 DIR_SRC=/data2/e1039/dst
-DIR_DEST=/pnfs/e1039/scratch/$USER/CalibChamXT/dst
+DIR_DEST=/pnfs/e1039/scratch/users/$USER/CalibChamXT/dst
 echo "LIST_RUN = $LIST_RUN"
 echo "DIR_SRC  = $DIR_SRC"
 echo "DIR_DEST = $DIR_DEST"

--- a/CalibChamXT/work/make_rt.sh
+++ b/CalibChamXT/work/make_rt.sh
@@ -7,7 +7,7 @@ DIR_BASE=$(dirname $(readlink -f $BASH_SOURCE))
 ITER=1
 LIST_RUN="list_run.txt"
 VERSION="main"
-DIR_DATA=/pnfs/e1039/scratch/$USER/CalibChamXT/$VERSION
+DIR_DATA=/pnfs/e1039/scratch/users/$USER/CalibChamXT/$VERSION
 
 LIST_DATA=scratch/list_input_data.txt
 mkdir -p scratch

--- a/CalibChamXT/work/run_reco.sh
+++ b/CalibChamXT/work/run_reco.sh
@@ -3,7 +3,7 @@ DIR_BASE=$(dirname $(readlink -f $BASH_SOURCE))
 
 LIST_RUN="list_run.txt"
 VERSION="main"
-DIR_DST=/pnfs/e1039/scratch/$USER/CalibChamXT/dst
+DIR_DST=/pnfs/e1039/scratch/users/$USER/CalibChamXT/dst
 
 USE_GRID=no
 N_DST_ANA=0 # N of DSTs per run to be analyzed
@@ -54,7 +54,7 @@ function ProcessOneRun {
 	    CMD+=" -d OUTPUT $DIR_WORK/$BASE_NAME/out"
 	    CMD+=" file://$DIR_WORK/$BASE_NAME/gridrun.sh $RUN $ITER $(basename $FN_DST) $N_EVT_ANA"
 	    #echo "$CMD"
-	    $CMD |& tee $DIR_WORK/$BASE_NAME/log_jobsub_submit.txt
+	    unbuffer $CMD |& tee $DIR_WORK/$BASE_NAME/log_jobsub_submit.txt
 	    RET_SUB=${PIPESTATUS[0]}
 	    test $RET_SUB -ne 0 && exit $RET_SUB
 	else
@@ -76,7 +76,7 @@ test "X$1" != 'XGO' && echo "Give 'GO' to make a real run." && exit 1
 
 if [ $USE_GRID = 'yes' ]; then
     echo "Grid mode."
-    DIR_DATA=/pnfs/e1039/scratch/$USER/CalibChamXT
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/CalibChamXT
     DIR_WORK=$DIR_DATA/$VERSION
     ln -nfs $DIR_DATA data # for convenience
 else

--- a/E1039Shielding/gridsub.sh
+++ b/E1039Shielding/gridsub.sh
@@ -18,7 +18,7 @@ fi
 echo "njobs=$njobs"
 echo "nevents=$nevents"
 
-macros=/e906/app/users/yuhw/seaquest-analysis/E1039Shielding
+macros=/e906/app/users/$USER/seaquest-analysis/E1039Shielding
 
 sed "s/nevents=NAN/nevents=$nevents/"             $macros/gridrun.sh > $macros/gridrun_new.sh 
 sed -i "s/shield=NAN/shield=$shield/"             $macros/gridrun_new.sh
@@ -26,7 +26,7 @@ sed -i "s/target_pos=NAN/target_pos=$target_pos/" $macros/gridrun_new.sh
 chmod +x $macros/gridrun_new.sh
 
 if [ $do_sub == 1 ]; then
-work=/pnfs/e906/persistent/users/yuhw/E1039Shielding/$jobname
+work=/pnfs/e1039/scratch/users/$USER/E1039Shielding/$jobname
 else
 work=$macros/scratch/$jobname
 fi

--- a/EvalJpsiAsymStat/macro_gen/gridsub.sh
+++ b/EvalJpsiAsymStat/macro_gen/gridsub.sh
@@ -30,7 +30,7 @@ echo "USE_GRID     = $USE_GRID"
 echo "JOB_B...E    = $JOB_B...$JOB_E"
 echo "N_EVT        = $N_EVT"
 if [ $USE_GRID == yes ]; then
-    DIR_DATA=/pnfs/e1039/scratch/$USER/EvalJpsiAsymStat
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/EvalJpsiAsymStat
     DIR_WORK=$DIR_DATA/$JOB_NAME
     ln -nfs $DIR_DATA data # for convenience
 else
@@ -65,7 +65,7 @@ for (( JOB_I = $JOB_B; JOB_I <= $JOB_E; JOB_I++ )) ; do
 	CMD+=" -f $DIR_WORK/input.tar.gz"
 	CMD+=" -d OUTPUT $DIR_WORK_JOB/out"
 	CMD+=" file://$DIR_WORK_JOB/gridrun.sh $JOB_NAME $N_EVT"
-	$CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/GenRoadset/macro_e906_nim3/gridsub.sh
+++ b/GenRoadset/macro_e906_nim3/gridsub.sh
@@ -35,7 +35,7 @@ echo "DO_OVERWRITE = $DO_OVERWRITE"
 echo "USE_GRID     = $USE_GRID"
 
 if [ $USE_GRID == yes ] ; then
-    DIR_WORK=/pnfs/e1039/scratch/$USER/GenRoadset/data_e906_nim3
+    DIR_WORK=/pnfs/e1039/scratch/users/$USER/GenRoadset/data_e906_nim3
     ln -nfs $DIR_WORK data # for convenience
 else
     DIR_WORK=$DIR_MACRO/scratch
@@ -84,7 +84,7 @@ while read DB_SERVER DB_SCHEMA RUN ROADSET ; do
 	CMD+=" -f $DIR_ROOT/$FN_ROOT"
 	CMD+=" -d OUTPUT $DIR_WORK_RUN/out"
 	CMD+=" file://$DIR_WORK_RUN/gridrun.sh $RUN $FN_ROOT $N_EVT"
-	$CMD |& tee $DIR_WORK_RUN/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_RUN/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/GenRoadset/macro_e906_nim3/merge-output-file.sh
+++ b/GenRoadset/macro_e906_nim3/merge-output-file.sh
@@ -4,7 +4,7 @@ DIR_MACRO=$(dirname $(readlink -f $BASH_SOURCE))
 
 RUN_LIST=/data2/production/list/R009/R009_fy2017.list
 DIR_IN=$DIR_MACRO/scratch
-DIR_OUT=/pnfs/e1039/persistent/users/$USER/GenRoadsetCommon
+DIR_OUT=/pnfs/e1039/scratch/users/$USER/GenRoadsetCommon
 FN_OUT=bg_data.root
 
 if [ -e $DIR_OUT ] ; then

--- a/GenRoadset/macro_full_bg/gridsub.sh
+++ b/GenRoadset/macro_full_bg/gridsub.sh
@@ -32,7 +32,7 @@ echo "USE_GRID     = $USE_GRID"
 echo "JOB_B...E    = $JOB_B...$JOB_E"
 echo "N_EVT        = $N_EVT"
 if [ $USE_GRID == yes ]; then
-    DIR_DATA=/pnfs/e1039/scratch/$USER/GenRoadset/data_full_bg
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/GenRoadset/data_full_bg
     DIR_WORK=$DIR_DATA/$JOB_NAME
     ln -nfs $DIR_DATA data # for convenience
 else
@@ -70,7 +70,7 @@ for (( JOB_I = $JOB_B; JOB_I <= $JOB_E; JOB_I++ )) ; do
 	CMD+=" -f $DIR_BKG/$FN_BKG"
 	CMD+=" -d OUTPUT $DIR_WORK_JOB/out"
 	CMD+=" file://$DIR_WORK_JOB/gridrun.sh $FN_BKG $N_EVT"
-	$CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/GenRoadset/macro_gen_signal/gridsub.sh
+++ b/GenRoadset/macro_gen_signal/gridsub.sh
@@ -30,7 +30,7 @@ echo "USE_GRID     = $USE_GRID"
 echo "JOB_B...E    = $JOB_B...$JOB_E"
 echo "N_EVT        = $N_EVT"
 if [ $USE_GRID == yes ]; then
-    DIR_DATA=/pnfs/e1039/scratch/$USER/GenRoadset/data_signal
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/GenRoadset/data_signal
     DIR_WORK=$DIR_DATA/$JOB_NAME
     ln -nfs $DIR_DATA data # for convenience
 else
@@ -65,7 +65,7 @@ for (( JOB_I = $JOB_B; JOB_I <= $JOB_E; JOB_I++ )) ; do
 	CMD+=" -f $DIR_WORK/input.tar.gz"
 	CMD+=" -d OUTPUT $DIR_WORK_JOB/out"
 	CMD+=" file://$DIR_WORK_JOB/gridrun.sh $N_EVT"
-	$CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/HitEmbedding/macro_embed/gridsub.sh
+++ b/HitEmbedding/macro_embed/gridsub.sh
@@ -52,7 +52,7 @@ echo "N_EMB        = $N_EMB"
 ## Prepare and execute the job submission
 ##
 if [ $USE_GRID == yes ]; then
-    DIR_DATA=/pnfs/e1039/scratch/$USER/HitEmbedding/data_embedded
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/HitEmbedding/data_embedded
     DIR_WORK=$DIR_DATA/$JOB_NAME
     ln -nfs $DIR_DATA data # for convenience
 else
@@ -92,7 +92,7 @@ for (( JOB_I = $JOB_B; JOB_I <= $JOB_E; JOB_I++ )) ; do
 	CMD+=" -f $FN_EMB"
 	CMD+=" -d OUTPUT $DIR_WORK_JOB/out"
 	CMD+=" file://$DIR_WORK_JOB/gridrun.sh $N_EVT"
-	$CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/HitEmbedding/macro_gen_emb/gridsub.sh
+++ b/HitEmbedding/macro_gen_emb/gridsub.sh
@@ -10,7 +10,7 @@ echo "DO_SUB   = $DO_SUB"
 echo "N_JOB    = $N_JOB"
 echo "N_EVT    = $N_EVT"
 if [ $DO_SUB == 1 ]; then
-    DIR_DATA=/pnfs/e1039/scratch/$USER/HitEmbedding/data_emb
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/HitEmbedding/data_emb
     DIR_WORK=$DIR_DATA/$JOB_NAME
     ln -nfs $DIR_DATA data # for convenience
 else
@@ -36,7 +36,7 @@ for (( I_JOB = 1; I_JOB <= $N_JOB; I_JOB++ )) ; do
 	CMD+=" -f $DIR_WORK/input.tar.gz"
 	CMD+=" -d OUTPUT $DIR_WORK/$I_JOB/out"
 	CMD+=" file://$DIR_WORK/$I_JOB/gridrun.sh $N_EVT $I_JOB"
-	$CMD |& tee $DIR_WORK/$I_JOB/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK/$I_JOB/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/HitEmbedding/macro_gen_emb_e906/gridsub.sh
+++ b/HitEmbedding/macro_gen_emb_e906/gridsub.sh
@@ -36,7 +36,7 @@ echo "USE_GRID     = $USE_GRID"
 
 if [ $USE_GRID == yes ] ; then
     #DIR_WORK=/pnfs/e1039/persistent/users/$USER/data_emb_e906
-    DIR_WORK=/pnfs/e1039/scratch/$USER/HitEmbedding/data_emb_e906
+    DIR_WORK=/pnfs/e1039/scratch/users/$USER/HitEmbedding/data_emb_e906
     ln -nfs $DIR_WORK data # for convenience
 else
     DIR_WORK=$DIR_MACRO/scratch
@@ -85,7 +85,7 @@ while read DB_SERVER DB_SCHEMA RUN ROADSET ; do
 	CMD+=" -f $DIR_ROOT/$FN_ROOT"
 	CMD+=" -d OUTPUT $DIR_WORK_RUN/out"
 	CMD+=" file://$DIR_WORK_RUN/gridrun.sh $RUN $FN_ROOT $N_EVT"
-	$CMD |& tee $DIR_WORK_RUN/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_RUN/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/HitEmbedding/macro_gen_emb_e906/merge-emb-file.sh
+++ b/HitEmbedding/macro_gen_emb_e906/merge-emb-file.sh
@@ -8,8 +8,7 @@ RUN_LIST=/data2/production/list/R009/R009_fy2017.list
 RUN_N=$(cat $RUN_LIST | wc -l)
 
 DIR_IN=scratch
-#DIR_OUT=/pnfs/e1039/scratch/$USER/data_emb_e906
-DIR_OUT=/pnfs/e1039/persistent/users/$USER/data_emb_e906
+DIR_OUT=/pnfs/e1039/scratch/users/$USER/data_emb_e906
 
 ##
 ## Function

--- a/HitEmbedding/macro_gen_signal/gridsub.sh
+++ b/HitEmbedding/macro_gen_signal/gridsub.sh
@@ -30,7 +30,7 @@ echo "USE_GRID     = $USE_GRID"
 echo "JOB_B...E    = $JOB_B...$JOB_E"
 echo "N_EVT        = $N_EVT"
 if [ $USE_GRID == yes ]; then
-    DIR_DATA=/pnfs/e1039/scratch/$USER/HitEmbedding/data_signal
+    DIR_DATA=/pnfs/e1039/scratch/users/$USER/HitEmbedding/data_signal
     DIR_WORK=$DIR_DATA/$JOB_NAME
     ln -nfs $DIR_DATA data # for convenience
 else
@@ -65,7 +65,7 @@ for (( JOB_I = $JOB_B; JOB_I <= $JOB_E; JOB_I++ )) ; do
 	CMD+=" -f $DIR_WORK/input.tar.gz"
 	CMD+=" -d OUTPUT $DIR_WORK_JOB/out"
 	CMD+=" file://$DIR_WORK_JOB/gridrun.sh $JOB_I $N_EVT"
-	$CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
+	unbuffer $CMD |& tee $DIR_WORK_JOB/log_jobsub_submit.txt
 	RET_SUB=${PIPESTATUS[0]}
 	test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/HodoAccGap/gridsub.sh
+++ b/HodoAccGap/gridsub.sh
@@ -18,7 +18,7 @@ fi
 echo "njobs=$njobs"
 echo "nevents=$nevents"
 
-macros=/e906/app/users/yuhw/seaquest-analysis/HodoAccGap
+macros=/e906/app/users/$USER/seaquest-analysis/HodoAccGap
 
 sed "s/nevents=NAN/nevents=$nevents/"             $macros/gridrun.sh > $macros/gridrun_new.sh 
 sed -i "s/gap=NAN/gap=$gap/"                      $macros/gridrun_new.sh
@@ -26,7 +26,7 @@ sed -i "s/target_pos=NAN/target_pos=$target_pos/" $macros/gridrun_new.sh
 chmod +x $macros/gridrun_new.sh
 
 if [ $do_sub == 1 ]; then
-work=/pnfs/e906/persistent/users/yuhw/HodoAccGap/$jobname
+work=/pnfs/e1039/scratch/users/$USER/HodoAccGap/$jobname
 else
 work=$macros/scratch/$jobname
 fi

--- a/PileupDev/macros/gridsub.sh
+++ b/PileupDev/macros/gridsub.sh
@@ -15,8 +15,8 @@ echo "njobs=$njobs"
 echo "nevents=$nevents"
 if [ $do_sub == 1 ]; then
     echo "Grid mode."
-    work=/pnfs/e1039/persistent/users/$USER/$PROJECT_NAME/$jobname
-    ln -nsf /pnfs/e1039/persistent/users/$USER/$PROJECT_NAME data
+    work=/pnfs/e1039/scratch/users/$USER/$PROJECT_NAME/$jobname
+    ln -nsf /pnfs/e1039/scratch/users/$USER/$PROJECT_NAME data
 else
     echo "Local mode."
     work=$dir_macros/scratch/$jobname

--- a/RecoDev/grid_script/gridsub_data.sh
+++ b/RecoDev/grid_script/gridsub_data.sh
@@ -14,8 +14,8 @@ echo "nevents=$nevents"
  
 if [ $do_sub == 1 ]; then
     echo "Grid mode."
-    work=/pnfs/e906/persistent/users/$USER/RecoDataDev/$jobname
-    ln -nfs /pnfs/e906/persistent/users/$USER/RecoDataDev data
+    work=/pnfs/e1039/scratch/users/$USER/RecoDataDev/$jobname
+    ln -nfs /pnfs/e1039/scratch/users/$USER/RecoDataDev data
 else
     echo "Local mode."
     work=$dir_macros/scratch/$jobname
@@ -29,8 +29,8 @@ tar -czvf $work/input.tar.gz  support RecoE1039Data.C
 cd -
 
 for run_num in $(cat $run_list) ; do  
-  #location of the data in your persistent area
-  data_dir="/pnfs/e906/persistent/users/$USER/DstRun"
+  #location of the data in your area
+  data_dir="/pnfs/e1039/scratch/users/$USER/DstRun"
   declare -a data_path_list=()
   if [ $dst_mode = 'single' ] ; then
       data_path_list=( $data_dir/$(printf 'run_%06d_spin.root' $run_num) )
@@ -56,7 +56,7 @@ for run_num in $(cat $run_list) ; do
       CMD+=" -f $data_path"
       CMD+=" file://$work/$job_name/gridrun_data.sh $nevents $run_num $data_file"
       echo "$CMD"
-      $CMD |& tee $work/$id/log_jobsub_submit.txt
+      unbuffer $CMD |& tee $work/$id/log_jobsub_submit.txt
       RET_SUB=${PIPESTATUS[0]}
       test $RET_SUB -ne 0 && exit $RET_SUB
     else

--- a/SimChainDev/Fun4Sim.C
+++ b/SimChainDev/Fun4Sim.C
@@ -340,7 +340,8 @@ int Fun4Sim(const int nevent = 10)
   //  se->registerOutputManager(out);
   //}
 
-  se->run(nevent);
+  const bool count_only_good_events = false;
+  se->run(nevent, count_only_good_events);
 
   PHGeomUtility::ExportGeomtry(se->topNode(),"geom.root");
   

--- a/SimChainDev/gridsub.sh
+++ b/SimChainDev/gridsub.sh
@@ -11,7 +11,7 @@ echo "njobs=$njobs"
 echo "nevents=$nevents"
 if [ $do_sub == 1 ]; then
     echo "Grid mode."
-    dir_data=/pnfs/e1039/scratch/$USER/SimChainDev
+    dir_data=/pnfs/e1039/scratch/users/$USER/SimChainDev
     work=$dir_data/$jobname
     ln -nfs $dir_data data # for convenience
 else
@@ -39,7 +39,7 @@ for (( id=1; id<=$njobs; id++ )) ; do
     CMD+=" -d OUTPUT $work/$id/out"
     CMD+=" file://$work/$id/gridrun.sh $nevents $id"
     echo "$CMD"
-    $CMD |& tee $work/$id/log_jobsub_submit.txt
+    unbuffer $CMD |& tee $work/$id/log_jobsub_submit.txt
     RET_SUB=${PIPESTATUS[0]}
     test $RET_SUB -ne 0 && exit $RET_SUB
   else

--- a/TargetSim/gridsub.sh
+++ b/TargetSim/gridsub.sh
@@ -15,14 +15,14 @@ fi
 echo "njobs=$njobs"
 echo "nevents=$nevents"
 
-macros=/e906/app/users/yuhw/e1039-analysis/TargetSim
+macros=/e906/app/users/$USER/e1039-analysis/TargetSim
 
 sed "s/nevents=NAN/nevents=$nevents/"             $macros/gridrun.sh > $macros/gridrun_new.sh 
 #sed -i "s/gap=NAN/gap=$gap/"                      $macros/gridrun_new.sh
 chmod +x $macros/gridrun_new.sh
 
 if [ $do_sub == 1 ]; then
-work=/pnfs/e906/persistent/users/yuhw/TargetSim/$jobname
+work=/pnfs/e1039/scratch/users/$USER/TargetSim/$jobname
 else
 work=$macros/scratch/$jobname
 fi

--- a/TriggerAna/work/gridsub.sh
+++ b/TriggerAna/work/gridsub.sh
@@ -14,7 +14,7 @@ echo "list=$list"
 
 if [ $do_sub == 1 ]; then
     echo "Grid mode."
-    dir_data=/pnfs/e1039/scratch/$USER/TriggerAna
+    dir_data=/pnfs/e1039/scratch/users/$USER/TriggerAna
     work=$dir_data/$jobname
     ln -nfs $dir_data data # for convenience
 else
@@ -43,7 +43,7 @@ do
     CMD+=" -d OUTPUT $work/$id/out"
     CMD+=" file://$work/$id/gridrun.sh $nfile $list $id"
     echo "$CMD"
-    $CMD |& tee $work/$id/log_jobsub_submit.txt
+    unbuffer $CMD |& tee $work/$id/log_jobsub_submit.txt
     RET_SUB=${PIPESTATUS[0]}
     test $RET_SUB -ne 0 && exit $RET_SUB
   else

--- a/TrkDev/gridsub.sh
+++ b/TrkDev/gridsub.sh
@@ -17,14 +17,14 @@ fi
 echo "njobs=$njobs"
 echo "nevents=$nevents"
 
-macros=/e906/app/users/yuhw/e1039-analysis/PrgTrkDev
+macros=/e906/app/users/$USER/e1039-analysis/PrgTrkDev
 
 sed "s/nevents=NAN/nevents=$nevents/"             $macros/gridrun.sh > $macros/gridrun_new.sh 
 sed -i "s/nmu=NAN/nmu=$nmu/"                      $macros/gridrun_new.sh
 chmod +x $macros/gridrun_new.sh
 
 if [ $do_sub == 1 ]; then
-work=/pnfs/e906/persistent/users/yuhw/PrgTrkDev/$jobname
+work=/pnfs/e1039/scratch/users/$USER/PrgTrkDev/$jobname
 else
 work=$macros/scratch/$jobname
 fi


### PR DESCRIPTION
This update is to make use of the new jobsub version, `jobsub_lite`.  I have modified only `SimChainDev/gridsub.sh` as an example.  If it seems fine, I will modify all other scripts before merging this PR.

Actually `gridsub.sh` was modified little;
1. The output directory was changed to `/pnfs/e1039/scratch/users/$USER`, where we are allowed to make output files under `users/`.
1. The job-submission command is wrapped with `unbuffer`, otherwise the message for the authentication is buffered by the shell pipe and thus not printed.

A larger modification was made on the wrapper script; `/e906/app/software/script/jobsub_submit_spinquest.sh`.
It was like this;
```
    jobsub_submit \
	--grid \
	-l '+SingularityImage=\"/cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest\"' \
	--append_condor_requirements='(TARGET.HAS_SINGULARITY=?=true)' \
	--use_gftp \
	--resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE \
	-e IFDHC_VERSION \
	--mail_never \
	$*
```
It is now like this;
```
    jobsub_submit  -G spinquest \
	--singularity-image /cvmfs/singularity.opensciencegrid.org/e1039/e1039-sl7:latest \
	--resource-provides=usage_model=DEDICATED,OPPORTUNISTIC,OFFSITE \
	$*
```
`--grid` and `--use_gftp` are no longer available and thus were removed.